### PR TITLE
Remove nil values from rows

### DIFF
--- a/lib/csvlint.rb
+++ b/lib/csvlint.rb
@@ -36,8 +36,8 @@ module Csvlint
         s.each_line do |line|
           begin
             current_line = current_line + 1
-            row = CSV.parse( line )[0]
-            expected_columns = row.count unless expected_columns != 0
+            row = CSV.parse( line )[0].reject(&:nil?)
+            expected_columns = row.count unless expected_columns != 0            
             build_errors(:ragged_rows, current_line) if row.count != expected_columns
           rescue CSV::MalformedCSVError => e
             type = fetch_error(e)


### PR DESCRIPTION
It seems that the CSV parser returns nil if there is a comma and then a blank. I don't think we want this, so I've stripped nil values from the generated array. Now https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/246500/New_Year_Honours_2013_full_list.csv/preview returns loads of errors, as expected
