### PR TITLE
Check the raw header contains /charset/

### DIFF
--- a/features/step_definitions/parse_csv_steps.rb
+++ b/features/step_definitions/parse_csv_steps.rb
@@ -9,6 +9,12 @@ Given(/^it is stored at the url "(.*?)"$/) do |url|
   stub_request(:get, url).to_return(:status => 200, :body => @csv, :headers => {"Content-Type" => "#{content_type}; charset=#{charset}"})
 end
 
+Given(/^it is stored at the url "(.*?)" with no character set header$/) do |url|
+  @url = url
+  content_type = @content_type || "text/csv"
+  stub_request(:get, url).to_return(:status => 200, :body => @csv, :headers => {"Content-Type" => "#{content_type}"})
+end
+
 When(/^I ask if the CSV is valid$/) do
   @validator = Csvlint::Validator.new( @url, @csv_options ) 
   @valid = @validator.valid?

--- a/features/validation_warnings.feature
+++ b/features/validation_warnings.feature
@@ -9,6 +9,17 @@ Feature: Validation warnings
     And it is stored at the url "http://example.com/example1.csv"
     When I ask if there are warnings
     Then there should be 0 warnings
+
+  Scenario: UTF-8 Encoding with no explicit header
+    Given I have a CSV with the following content:
+    """
+"abc","2","3"
+    """
+    And it is encoded as "utf-8"
+    And it is stored at the url "http://example.com/example1.csv" with no character set header
+    When I ask if there are warnings
+    Then there should be 1 warnings
+    And that warning should have the type "encoding_not_set"
     
    Scenario: ISO-8859-1 Encoding
     Given I have a CSV with the following content:

--- a/lib/csvlint.rb
+++ b/lib/csvlint.rb
@@ -34,9 +34,13 @@ module Csvlint
       single_col = false
       build_warnings(:extension, nil) unless @extension == ".csv"
       open(@stream) do |s|
-        @encoding = s.charset rescue nil
-        @content_type = s.content_type rescue nil
-        build_warnings(:encoding, nil) if @encoding != "utf-8"
+        @encoding = s.charset
+        @content_type = s.content_type
+        if s.meta["content-type"] !~ /charset/
+          build_warnings(:encoding_not_set, nil) 
+        else
+          build_warnings(:encoding, nil) if @encoding != "utf-8"
+        end
         build_warnings(:content_type, nil) unless @content_type =~ /text\/csv|application\/csv|text\/comma-separated-values/
         s.each_line(@line_terminator) do |line|
           begin


### PR DESCRIPTION
Needed for #3 

This basically sets a warning if there is no character set sent in the `content-type` header.
