### PR TITLE
Report trailing empty rows as an error. Previously threw exception

### DIFF
--- a/features/step_definitions/validation_errors_steps.rb
+++ b/features/step_definitions/validation_errors_steps.rb
@@ -18,3 +18,7 @@ end
 Then(/^that error should have the content "(.*)"$/) do |content|
   @errors.first.content.chomp.should == content.chomp
 end
+
+Then(/^that error should have no content$/) do
+  @errors.first.content.should == nil
+end

--- a/features/validation_errors.feature
+++ b/features/validation_errors.feature
@@ -50,6 +50,22 @@ Feature: Get validation errors
     And that error should have the type "blank_rows"
     And that error should have the row "2"
     And that error should have the content ""","","
+
+  Scenario: Successfully report a CSV with trailing empty row
+    Given I have a CSV with the following content:
+    """
+"Foo","Bar","Baz"
+"Foo","Bar","Baz"
+
+
+    """
+    And it is stored at the url "http://example.com/example1.csv"
+    When I ask if there are errors
+    Then there should be 1 error
+    And that error should have the type "blank_rows"
+    And that error should have the row "3"
+    And that error should have no content
+
     
    Scenario: Report invalid Encoding
     Given I have a CSV file called "invalid-byte-sequence.csv"

--- a/lib/csvlint/validate.rb
+++ b/lib/csvlint/validate.rb
@@ -47,13 +47,17 @@ module Csvlint
         s.each_line(@line_terminator) do |line|
           begin
             current_line = current_line + 1
-            @csv_options[:encoding] = @encoding
+            @csv_options[:encoding] = @encoding            
             row = CSV.parse(line.chomp(@line_terminator), @csv_options)[0]
-            build_formats(row, current_line)
-            single_col = true if row.count == 1
-            expected_columns = row.count unless expected_columns != 0
-            build_errors(:ragged_rows, current_line, line) if row.count != expected_columns
-            build_errors(:blank_rows, current_line, line) if row.reject{ |c| c.nil? || c.empty? }.count == 0
+            if row
+              build_formats(row, current_line)
+              single_col = true if row.count == 1
+              expected_columns = row.count unless expected_columns != 0
+              build_errors(:ragged_rows, current_line, line) if row.count != expected_columns
+              build_errors(:blank_rows, current_line, line) if row.reject{ |c| c.nil? || c.empty? }.count == 0
+            else
+              build_errors(:blank_rows, current_line, nil)
+            end
           rescue CSV::MalformedCSVError => e
             type = fetch_error(e)
             build_errors(type, current_line, line)


### PR DESCRIPTION
https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/15240/1871702.csv was causing code to blow up due to empty row at end of file.

Fixed and made this a blank_row error.
