### PR TITLE
Added open_uri_redirections to allow HTTP/HTTPS transfers

### DIFF
--- a/csvlint.gemspec
+++ b/csvlint.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   
   spec.add_dependency "mime-types"
   spec.add_dependency "colorize"
+  spec.add_dependency "open_uri_redirections"
   
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/lib/csvlint/validate.rb
+++ b/lib/csvlint/validate.rb
@@ -1,3 +1,5 @@
+require "open_uri_redirections"
+
 module Csvlint
   
   class Validator
@@ -31,7 +33,7 @@ module Csvlint
       single_col = false   
       io = nil   
       begin
-        io = @source.respond_to?(:gets) ? @source : open(@source)
+        io = @source.respond_to?(:gets) ? @source : open(@source, :allow_redirections=>:all)
         validate_metadata(io)
         columns = parse_csv(io)
         build_warnings(:check_options, :structure) if columns == 1        

--- a/spec/validator_spec.rb
+++ b/spec/validator_spec.rb
@@ -166,5 +166,14 @@ describe Csvlint::Validator do
     end
     
   end
+  
+  it "should follow redirects to SSL" do
+    stub_request(:get, "http://example.com/redirect").to_return(:status => 301, :headers=>{"Location" => "https://example.com/example.csv"})
+    stub_request(:get, "https://example.com/example.csv").to_return(:status => 200, 
+        :headers=>{"Content-Type" => "text/csv"}, 
+        :body => File.read(File.join(File.dirname(__FILE__),'..','features','fixtures','valid.csv')))
 
+    validator = Csvlint::Validator.new("http://example.com/redirect")    
+    expect( validator.valid? ).to eql(true)
+  end
 end


### PR DESCRIPTION
By default open-uri doesn't allow HTTP->HTTPS or HTTPS->HTTP redirects and this is causing the error reports in theodi/csvlint#53.

Added the open_uri_redirections gem which patches open-uri and we now allow both types of redirection.

@floppy can you think of any issues with this? (I can't as its all open data, but wanted a second opinion).
