### PR TITLE
Fix ignore empty fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Supported constraints:
 
 Supported data types (this is still a work in progress):
 
+* String -- `http://www.w3.org/2001/XMLSchema#string` (effectively a no-op)
 * Integer -- `http://www.w3.org/2001/XMLSchema#int`
 * Float -- `http://www.w3.org/2001/XMLSchema#float`
 * Double -- `http://www.w3.org/2001/XMLSchema#double`
@@ -186,6 +187,8 @@ Supported data types (this is still a work in progress):
 * Year -- `http://www.w3.org/2001/XMLSchema#gYear`
 * Year Month -- `http://www.w3.org/2001/XMLSchema#gYearMonth`
 * Time -- `http://www.w3.org/2001/XMLSchema#time`
+
+Use of an unknown data type will result in the column failing to validate.
 	
 Schema validation provides some additional types of error and warning messages:
 

--- a/lib/csvlint/field.rb
+++ b/lib/csvlint/field.rb
@@ -9,6 +9,7 @@ module Csvlint
     attr_reader :name, :constraints, :title, :description
 
     TYPE_VALIDATIONS = {
+        'http://www.w3.org/2001/XMLSchema#string'     => lambda { |value, constraints| value },
         'http://www.w3.org/2001/XMLSchema#int'     => lambda { |value, constraints| Integer value },
         'http://www.w3.org/2001/XMLSchema#float'   => lambda { |value, constraints| Float value },
         'http://www.w3.org/2001/XMLSchema#double'   => lambda { |value, constraints| Float value },

--- a/spec/field_spec.rb
+++ b/spec/field_spec.rb
@@ -56,6 +56,12 @@ describe Csvlint::Field do
       expect( field.validate_column("")).to be(true)
     end
     
+    it "validates strings" do
+      field = Csvlint::Field.new("test", { "type" => "http://www.w3.org/2001/XMLSchema#string" })
+      expect( field.validate_column("42")).to be(true)
+      expect( field.validate_column("forty-two")).to be(true)
+    end
+    
     it "validates ints" do
       field = Csvlint::Field.new("test", { "type" => "http://www.w3.org/2001/XMLSchema#int" })
       expect( field.validate_column("42")).to be(true)


### PR DESCRIPTION
Only apply type validation if value is not empty
Allow xsd:string, although we do nothing to the value, avoids an error
