### PR TITLE
Add failed constraints to schema errors

### DIFF
--- a/lib/csvlint/error_collector.rb
+++ b/lib/csvlint/error_collector.rb
@@ -2,13 +2,14 @@ module Csvlint
   
   module ErrorCollector
       
-    def build_message(type, category, row, column, content)
+    def build_message(type, category, row, column, content, constraints)
       Csvlint::ErrorMessage.new({
                                   :type => type,
                                   :category => category,
                                   :row => row,
                                   :column => column,
-                                  :content => content
+                                  :content => content,
+                                  :constraints => constraints
                                 })
     end
     
@@ -22,8 +23,8 @@ module Csvlint
       
       attr_reader level
       
-      define_method "build_#{level}" do |type, category = nil, row = nil, column = nil, content = nil|
-        instance_variable_get("@#{level}") << build_message(type, category, row, column, content)
+      define_method "build_#{level}" do |type, category = nil, row = nil, column = nil, content = nil, constraints = {}|
+        instance_variable_get("@#{level}") << build_message(type, category, row, column, content, constraints)
       end
       
     end

--- a/lib/csvlint/error_message.rb
+++ b/lib/csvlint/error_message.rb
@@ -2,7 +2,7 @@ module Csvlint
 
   class ErrorMessage
   
-    attr_reader :type, :category, :row, :column, :content
+    attr_reader :type, :category, :row, :column, :content, :constraints
   
     def initialize(params)
       params.each do |key, value|

--- a/lib/csvlint/field.rb
+++ b/lib/csvlint/field.rb
@@ -96,23 +96,27 @@ module Csvlint
     private
       def validate_length(value, row, column)
         if constraints["required"] == true
-          build_errors(:missing_value, :schema, row, column, value) if value.nil? || value.length == 0
+          build_errors(:missing_value, :schema, row, column, value, 
+            { "required" => true }) if value.nil? || value.length == 0
         end
         if constraints["minLength"]
-          build_errors(:min_length, :schema, row, column, value) if value.nil? || value.length < constraints["minLength"]
+          build_errors(:min_length, :schema, row, column, value, 
+            { "minLength" => constraints["minLength"] }) if value.nil? || value.length < constraints["minLength"]
         end
         if constraints["maxLength"]
-            build_errors(:max_length, :schema, row, column, value) if !value.nil? && value.length > constraints["maxLength"]
+            build_errors(:max_length, :schema, row, column, value,
+             { "maxLength" => constraints["maxLength"] } ) if !value.nil? && value.length > constraints["maxLength"]
         end
       end
       
       def validate_values(value, row, column)
         if constraints["pattern"]
-          build_errors(:pattern, :schema, row, column, value) if !value.nil? && !value.match( constraints["pattern"] )
+          build_errors(:pattern, :schema, row, column, value, 
+           { "pattern" => constraints["pattern"] } ) if !value.nil? && !value.match( constraints["pattern"] )
         end
         if constraints["unique"] == true
           if @uniques.include? value
-            build_errors(:unique, :schema, row, column, value)
+            build_errors(:unique, :schema, row, column, value, { "unique" => true })
           else
             @uniques << value
           end
@@ -123,7 +127,9 @@ module Csvlint
         if constraints["type"] && value != ""
           parsed = convert_to_type(value)
           if parsed == nil
-            build_errors(:invalid_type, :schema, row, column, value)
+            failed = { "type" => constraints["type"] }
+            failed["datePattern"] = constraints["datePattern"] if constraints["datePattern"]
+            build_errors(:invalid_type, :schema, row, column, value, failed)
             return nil
           end
           return parsed
@@ -137,13 +143,15 @@ module Csvlint
         if constraints["minimum"]
           minimumValue = convert_to_type( constraints["minimum"] )
           if minimumValue
-            build_errors(:below_minimum, :schema, row, column, value) unless value >= minimumValue
+            build_errors(:below_minimum, :schema, row, column, value, 
+              { "minimum" => constraints["minimum"] }) unless value >= minimumValue
           end
         end
         if constraints["maximum"]
           maximumValue = convert_to_type( constraints["maximum"] )
           if maximumValue
-            build_errors(:above_maximum, :schema, row, column, value) unless value <= maximumValue
+            build_errors(:above_maximum, :schema, row, column, value, 
+            { "maximum" => constraints["maximum"] }) unless value <= maximumValue
           end
         end
       end


### PR DESCRIPTION
Closes #64.

Schema messages will now have a constraints hash that holds the relevant constraint that failed. This is useful for some errors as we can provide more detail in the application about what failed, e.g. the minLength, minimum range, date pattern, etc.
