### PR TITLE
Fixed warning - use expect( ) rather than .should

### DIFF
--- a/features/step_definitions/information_steps.rb
+++ b/features/step_definitions/information_steps.rb
@@ -4,10 +4,10 @@ end
 
 Then(/^the "(.*?)" should be "(.*?)"$/) do |type, encoding|
   validator = Csvlint::Validator.new( @url, default_csv_options ) 
-  validator.send(type.to_sym).should == encoding
+  expect( validator.send(type.to_sym) ).to eq( encoding )
 end
 
 Then(/^the metadata content type should be "(.*?)"$/) do |content_type|
   validator = Csvlint::Validator.new( @url, default_csv_options ) 
-  validator.headers['content-type'].should == content_type
+  expect( validator.headers['content-type'] ).to eq( content_type )
 end

--- a/features/step_definitions/validation_errors_steps.rb
+++ b/features/step_definitions/validation_errors_steps.rb
@@ -1,36 +1,36 @@
 When(/^I ask if there are errors$/) do
   @csv_options ||= default_csv_options
-  
+
   if @schema_json
     @schema = Csvlint::Schema.from_json_table( @schema_url || "http://example.org ", JSON.parse(@schema_json) )
   end
-  
-  @validator = Csvlint::Validator.new( @url, @csv_options, @schema ) 
+
+  @validator = Csvlint::Validator.new( @url, @csv_options, @schema )
   @errors = @validator.errors
 end
 
-Then(/^there should be (\d+) error$/) do |count|  
-  @errors.count.should == count.to_i
+Then(/^there should be (\d+) error$/) do |count|
+  expect( @errors.count ).to eq( count.to_i )
 end
 
 Then(/^that error should have the type "(.*?)"$/) do |type|
-  @errors.first.type.should == type.to_sym
+  expect( @errors.first.type ).to eq( type.to_sym )
 end
 
 Then(/^that error should have the row "(.*?)"$/) do |row|
-  @errors.first.row.should == row.to_i
+  expect( @errors.first.row ).to eq( row.to_i )
 end
 
 Then(/^that error should have the column "(.*?)"$/) do |column|
-  @errors.first.column.should == column.to_i
+  expect( @errors.first.column ).to eq( column.to_i )
 end
 
 Then(/^that error should have the content "(.*)"$/) do |content|
-  @errors.first.content.chomp.should == content.chomp
+  expect( @errors.first.content.chomp ).to eq( content.chomp )
 end
 
 Then(/^that error should have no content$/) do
-  @errors.first.content.should == nil
+  expect( @errors.first.content ).to eq( nil )
 end
 
 Given(/^I have a CSV that doesn't exist$/) do

--- a/features/step_definitions/validation_info_steps.rb
+++ b/features/step_definitions/validation_info_steps.rb
@@ -10,9 +10,9 @@ Given(/^I ask if there are info messages$/) do
 end
 
 Then(/^there should be (\d+) info messages?$/) do |num|
-  @info_messages.count.should == num.to_i
+  expect( @info_messages.count ).to eq( num.to_i )
 end
 
 Then(/^one of the messages should have the type "(.*?)"$/) do |msg_type|
-  @info_messages.find{|x| x.type == msg_type.to_sym}.should be_present
+  expect( @info_messages.find{|x| x.type == msg_type.to_sym} ).to be_present
 end

--- a/features/step_definitions/validation_warnings_steps.rb
+++ b/features/step_definitions/validation_warnings_steps.rb
@@ -21,12 +21,12 @@ When(/^I ask if there are warnings$/) do
     @schema = Csvlint::Schema.from_json_table( @schema_url || "http://example.org ", JSON.parse(@schema_json) )
   end
 
-  @validator = Csvlint::Validator.new( @url, @csv_options, @schema ) 
+  @validator = Csvlint::Validator.new( @url, @csv_options, @schema )
   @warnings = @validator.warnings
 end
 
 Then(/^there should be (\d+) warnings$/) do |count|
-  @warnings.count.should == count.to_i
+  expect( @warnings.count ).to eq( count.to_i )
 end
 
 Given(/^the content type is set to "(.*?)"$/) do |type|
@@ -34,13 +34,13 @@ Given(/^the content type is set to "(.*?)"$/) do |type|
 end
 
 Then(/^that warning should have the row "(.*?)"$/) do |row|
-  @warnings.first.row.should == row.to_i
+  expect( @warnings.first.row ).to eq( row.to_i )
 end
 
 Then(/^that warning should have the column "(.*?)"$/) do |column|
-  @warnings.first.column.should == column.to_i
+  expect( @warnings.first.column ).to eq( column.to_i )
 end
 
 Then(/^that warning should have the type "(.*?)"$/) do |type|
-  @warnings.first.type.should == type.to_sym
+  expect( @warnings.first.type ).to eq( type.to_sym )
 end


### PR DESCRIPTION
Ruby builds always seem pretty chatty. The warnings about .should are pretty benign, but this patch silences it so quites the build down a touch.