### PR TITLE
Emit a warning when the CSV header does not match the supplied schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Schema validation provides some additional types of error and warning messages:
 * `:min_length` (error) -- a column with a `minLength` constraint has a value that is too short
 * `:max_length` (error) -- a column with a `maxLength` constraint has a value that is too long
 * `:pattern` (error) --  a column with a `pattern` constraint has a value that doesn't match the regular expression
-* `:header_name` (warning) -- the header in the CSV has a column name that doesn't match the schema
+* `:malformed_header` (warning) -- the header in the CSV doesn't match the schema
 * `:missing_column` (warning) -- a row in the CSV file has a missing column, that is specified in the schema. This is a warning only, as it may be legitimate
 * `:extra_column` (warning) -- a row in the CSV file has extra column.
 * `:unique` (error) -- a column with a `unique` constraint contains non-unique values

--- a/README.md
+++ b/README.md
@@ -191,14 +191,15 @@ Supported data types (this is still a work in progress):
 * Time -- `http://www.w3.org/2001/XMLSchema#time`
 
 Use of an unknown data type will result in the column failing to validate.
-	
+
 Schema validation provides some additional types of error and warning messages:
 
 * `:missing_value` (error) -- a column marked as `required` in the schema has no value
 * `:min_length` (error) -- a column with a `minLength` constraint has a value that is too short
 * `:max_length` (error) -- a column with a `maxLength` constraint has a value that is too long
-* `:pattern` (error) --  a column with a `pattern` constraint has a value that doesn't match the regular expression
+* `:pattern` (error) -- a column with a `pattern` constraint has a value that doesn't match the regular expression
 * `:header_name` (warning) -- the header in the CSV has a column name that doesn't match the schema
+* `:header_count` (warning) -- the header in the CSV has a column count that doesn't match the schema
 * `:missing_column` (warning) -- a row in the CSV file has a missing column, that is specified in the schema. This is a warning only, as it may be legitimate
 * `:extra_column` (warning) -- a row in the CSV file has extra column.
 * `:unique` (error) -- a column with a `unique` constraint contains non-unique values

--- a/bin/csvlint
+++ b/bin/csvlint
@@ -3,15 +3,57 @@ $:.unshift File.join( File.dirname(__FILE__), "..", "lib")
 
 require 'csvlint'
 require 'colorize'
+require 'json'
+require 'optparse'
+require 'pp'
 
-def print_error(index, error, color=:red)
+options = {}
+opts = OptionParser.new
+
+opts.banner = "Usage: csvlint [options] [file]"
+
+opts.on("-d", "--dump-errors", "Pretty print error and warning objects.") do |d|
+  options[:dump] = d
+end
+
+opts.on("-s", "--schema-file FILENAME", "Schema file") do |s|
+  options[:schema_file] = s
+end
+q
+opts.on_tail("-h", "--help",
+             "Show this message") do
+  puts opts
+  exit
+end
+
+begin
+  opts.parse!
+rescue OptionParser::InvalidOption => e
+  puts e
+  puts opts
+  exit(1)
+end
+
+def print_error(index, error, dump, color)
+
   location = ""
   location += error.row.to_s if error.row
   location += "#{error.row ? "," : ""}#{error.column.to_s}" if error.column
   if error.row || error.column
     location = "#{error.row ? "Row" : "Column"}: #{location}"
   end
-  puts "#{index+1}. #{error.type}. #{location}".colorize(color)
+  output_string = "#{index+1}. #{error.type}. #{location}"
+
+  if $stdout.tty?
+    puts output_string.colorize(color)
+  else
+    puts output_string
+  end
+
+  if dump
+    pp error
+  end
+
 end
 
 if ARGV.length == 0 && !$stdin.tty?
@@ -23,29 +65,45 @@ else
       begin
         source = File.new( source ) unless source =~ /^http(s)?/ 
       rescue Errno::ENOENT
-        puts "File not found"
+        puts "#{source} not found"
         exit 1
       end
     end
   else
-    puts "Usage: csvlint {file or URL} or {input} | csvlint"
+    puts "No CSV data to validate."
+    puts opts
     exit 1
   end
 end
 
-validator = Csvlint::Validator.new( source )
+schema = nil
+if options[:schema_file]
+  begin
+    schemafile = File.read( options[:schema_file] )
+  rescue Errno::ENOENT
+    puts "#{options[:schema_file]} not found"
+    exit 1
+  end
+  schema = Csvlint::Schema.from_json_table(nil, JSON.parse(schemafile))
+end
 
-puts "#{ARGV[0] || "CSV"} is #{validator.valid? ? "VALID".green : "INVALID".red}"
+validator = Csvlint::Validator.new( source, nil, schema )
+
+if $stdout.tty?
+  puts "#{ARGV[0] || "CSV"} is #{validator.valid? ? "VALID".green : "INVALID".red}"
+else
+  puts "#{ARGV[0] || "CSV"} is #{validator.valid? ? "VALID" : "INVALID"}"
+end
 
 if validator.errors.size > 0
   validator.errors.each_with_index do |error, i|
-    print_error(i, error)
+    print_error(i, error, options[:dump], :red)
   end
 end
 
 if validator.warnings.size > 0
   validator.warnings.each_with_index do |error, i|
-    print_error(i, error, :yellow)
+    print_error(i, error, options[:dump], :yellow)
   end
 end
 

--- a/lib/csvlint/schema.rb
+++ b/lib/csvlint/schema.rb
@@ -17,10 +17,6 @@ module Csvlint
     def validate_header(header)
       reset
 
-      #if header.size != fields.size
-      #  build_warnings(:header_count, :schema, nil, 1, "#{fields.size} header field(s) specified but found #{header.size}")
-      #end
-
       found_header = header.join(',')
       expected_header = @fields.map{ |f| f.name }.join(',')
       if found_header != expected_header

--- a/lib/csvlint/schema.rb
+++ b/lib/csvlint/schema.rb
@@ -16,9 +16,17 @@ module Csvlint
 
     def validate_header(header)
       reset
-      header.each_with_index do |name,i|
-        build_warnings(:header_name, :schema, nil, i+1, name) if fields[i].name != name
+
+      if header.size != fields.size
+        build_warnings(:header_count, :schema, nil, 1, "#{fields.size} header field(s) specified but found #{header.size}")
       end
+
+      header.each_with_index do |name,i|
+        if fields.size < i+1 || fields[i].name != name
+          build_warnings(:header_name, :schema, nil, i+1, name)
+        end
+      end
+
       return valid?
     end
         

--- a/lib/csvlint/schema.rb
+++ b/lib/csvlint/schema.rb
@@ -17,14 +17,14 @@ module Csvlint
     def validate_header(header)
       reset
 
-      if header.size != fields.size
-        build_warnings(:header_count, :schema, nil, 1, "#{fields.size} header field(s) specified but found #{header.size}")
-      end
+      #if header.size != fields.size
+      #  build_warnings(:header_count, :schema, nil, 1, "#{fields.size} header field(s) specified but found #{header.size}")
+      #end
 
-      header.each_with_index do |name,i|
-        if fields.size < i+1 || fields[i].name != name
-          build_warnings(:header_name, :schema, nil, i+1, name)
-        end
+      found_header = header.join(',')
+      expected_header = @fields.map{ |f| f.name }.join(',')
+      if found_header != expected_header
+        build_warnings(:malformed_header, :schema, 1, nil, found_header, expected_header)
       end
 
       return valid?

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -81,9 +81,10 @@ describe Csvlint::Schema do
 
     #no ragged row error    
     expect( schema.errors.size ).to eql(0)        
-  end  
+  end
 
   context "when validating header" do
+
     it "should warn if column names are different to field names" do
       minimum = Csvlint::Field.new("minimum", { "minLength" => 3 } )
       required = Csvlint::Field.new("required", { "required" => true } )
@@ -94,16 +95,55 @@ describe Csvlint::Schema do
       
       expect( schema.validate_header(["wrong", "required"]) ).to eql(true)
       expect( schema.warnings.size ).to eql(1)
-      expect( schema.warnings.first.type).to eql(:header_name)
-      expect( schema.warnings.first.content).to eql("wrong")
-      expect( schema.warnings.first.column).to eql(1)
-      expect( schema.warnings.first.category).to eql(:schema)
+      expect( schema.warnings.first.type ).to eql(:header_name)
+      expect( schema.warnings.first.content ).to eql("wrong")
+      expect( schema.warnings.first.column ).to eql(1)
+      expect( schema.warnings.first.category ).to eql(:schema)
       
       expect( schema.validate_header(["minimum", "Required"]) ).to eql(true)
       expect( schema.warnings.size ).to eql(1)
 
-    end        
-  end  
+    end
+
+    it "should warn if column count is less than field count" do
+      minimum = Csvlint::Field.new("minimum", { "minLength" => 3 } )
+      required = Csvlint::Field.new("required", { "required" => true } )
+      schema = Csvlint::Schema.new("http://example.org", [minimum, required] )
+
+      expect( schema.validate_header(["minimum"]) ).to eql(true)
+      expect( schema.warnings.size ).to eql(1)
+      expect( schema.warnings.first.type ).to eql(:header_count)
+      expect( schema.warnings.first.content ).to eql("2 header field(s) specified but found 1")
+      expect( schema.warnings.first.column ).to eql(1)
+      expect( schema.warnings.first.category ).to eql(:schema)
+
+    end
+
+    it "should warn if column count is more than field count" do
+      minimum = Csvlint::Field.new("minimum", { "minLength" => 3 } )
+      schema = Csvlint::Schema.new("http://example.org", [minimum] )
+
+      expect( schema.validate_header(["wrong", "required"]) ).to eql(true)
+      expect( schema.warnings.size ).to eql(3)
+
+      expect( schema.warnings.first.type ).to eql(:header_count)
+      expect( schema.warnings.first.content ).to eql("1 header field(s) specified but found 2")
+      expect( schema.warnings.first.column ).to eql(1)
+      expect( schema.warnings.first.category ).to eql(:schema)
+
+      expect( schema.warnings[1].type ).to eql(:header_name)
+      expect( schema.warnings[1].content ).to eql("wrong")
+      expect( schema.warnings[1].column ).to eql(1)
+      expect( schema.warnings[1].category ).to eql(:schema)
+
+      expect( schema.warnings[2].type ).to eql(:header_name)
+      expect( schema.warnings[2].content ).to eql("required")
+      expect( schema.warnings[2].column ).to eql(2)
+      expect( schema.warnings[2].category ).to eql(:schema)
+
+    end
+
+  end
   
   context "when parsing JSON Tables" do
     

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -95,10 +95,12 @@ describe Csvlint::Schema do
       
       expect( schema.validate_header(["wrong", "required"]) ).to eql(true)
       expect( schema.warnings.size ).to eql(1)
-      expect( schema.warnings.first.type ).to eql(:header_name)
-      expect( schema.warnings.first.content ).to eql("wrong")
-      expect( schema.warnings.first.column ).to eql(1)
+      expect( schema.warnings.first.row ).to eql(1)
+      expect( schema.warnings.first.type ).to eql(:malformed_header)
+      expect( schema.warnings.first.content ).to eql('wrong,required')
+      expect( schema.warnings.first.column ).to eql(nil)
       expect( schema.warnings.first.category ).to eql(:schema)
+      expect( schema.warnings.first.constraints ).to eql('minimum,required')
       
       expect( schema.validate_header(["minimum", "Required"]) ).to eql(true)
       expect( schema.warnings.size ).to eql(1)
@@ -112,10 +114,12 @@ describe Csvlint::Schema do
 
       expect( schema.validate_header(["minimum"]) ).to eql(true)
       expect( schema.warnings.size ).to eql(1)
-      expect( schema.warnings.first.type ).to eql(:header_count)
-      expect( schema.warnings.first.content ).to eql("2 header field(s) specified but found 1")
-      expect( schema.warnings.first.column ).to eql(1)
+      expect( schema.warnings.first.row ).to eql(1)
+      expect( schema.warnings.first.type ).to eql(:malformed_header)
+      expect( schema.warnings.first.content ).to eql("minimum")
+      expect( schema.warnings.first.column ).to eql(nil)
       expect( schema.warnings.first.category ).to eql(:schema)
+      expect( schema.warnings.first.constraints ).to eql('minimum,required')
 
     end
 
@@ -124,22 +128,13 @@ describe Csvlint::Schema do
       schema = Csvlint::Schema.new("http://example.org", [minimum] )
 
       expect( schema.validate_header(["wrong", "required"]) ).to eql(true)
-      expect( schema.warnings.size ).to eql(3)
-
-      expect( schema.warnings.first.type ).to eql(:header_count)
-      expect( schema.warnings.first.content ).to eql("1 header field(s) specified but found 2")
-      expect( schema.warnings.first.column ).to eql(1)
+      expect( schema.warnings.size ).to eql(1)
+      expect( schema.warnings.first.row ).to eql(1)
+      expect( schema.warnings.first.type ).to eql(:malformed_header)
+      expect( schema.warnings.first.content ).to eql("wrong,required")
+      expect( schema.warnings.first.column ).to eql(nil)
       expect( schema.warnings.first.category ).to eql(:schema)
-
-      expect( schema.warnings[1].type ).to eql(:header_name)
-      expect( schema.warnings[1].content ).to eql("wrong")
-      expect( schema.warnings[1].column ).to eql(1)
-      expect( schema.warnings[1].category ).to eql(:schema)
-
-      expect( schema.warnings[2].type ).to eql(:header_name)
-      expect( schema.warnings[2].content ).to eql("required")
-      expect( schema.warnings[2].column ).to eql(2)
-      expect( schema.warnings[2].category ).to eql(:schema)
+      expect( schema.warnings.first.constraints ).to eql('minimum')
 
     end
 


### PR DESCRIPTION
This feature fixes #126. Happy to make changes if requested. Ruby is not my first language.