### PR TITLE
Validate header size improvement

### DIFF
--- a/lib/csvlint/schema.rb
+++ b/lib/csvlint/schema.rb
@@ -17,8 +17,8 @@ module Csvlint
     def validate_header(header)
       reset
 
-      found_header = header.join(',')
-      expected_header = @fields.map{ |f| f.name }.join(',')
+      found_header = header.to_csv(:row_sep => '')
+      expected_header = @fields.map{ |f| f.name }.to_csv(:row_sep => '')
       if found_header != expected_header
         build_warnings(:malformed_header, :schema, 1, nil, found_header, expected_header)
       end


### PR DESCRIPTION
This small change uses the CSV module rather than a naive join(',') to create the observed vs expected headers in the error message. This will result in better messages if headers include commas.