### PR TITLE
Malformed header reporting improvements

### DIFF
--- a/lib/csvlint/schema.rb
+++ b/lib/csvlint/schema.rb
@@ -19,7 +19,7 @@ module Csvlint
 
       expected_header = @fields.map{ |f| f.name }
 
-      if header != expected_header
+      if header.to_set != expected_header.to_set
         build_warnings(:malformed_header, :schema, 1, nil, header, expected_header)
       end
       

--- a/lib/csvlint/schema.rb
+++ b/lib/csvlint/schema.rb
@@ -17,12 +17,12 @@ module Csvlint
     def validate_header(header)
       reset
 
-      found_header = header.join(',')
-      expected_header = @fields.map{ |f| f.name }.join(',')
-      if found_header != expected_header
-        build_warnings(:malformed_header, :schema, 1, nil, found_header, expected_header)
-      end
+      expected_header = @fields.map{ |f| f.name }
 
+      if header != expected_header
+        build_warnings(:malformed_header, :schema, 1, nil, header, expected_header)
+      end
+      
       return valid?
     end
         

--- a/lib/csvlint/schema.rb
+++ b/lib/csvlint/schema.rb
@@ -1,11 +1,11 @@
 module Csvlint
-
+  
   class Schema
-
+    
     include Csvlint::ErrorCollector
-
+    
     attr_reader :uri, :fields, :title, :description
-
+    
     def initialize(uri, fields=[], title=nil, description=nil)
       @uri = uri
       @fields = fields
@@ -17,19 +17,15 @@ module Csvlint
     def validate_header(header)
       reset
 
-      found_header = header.to_csv(:row_sep => '')
-      expected_header = @fields.map{ |f| f.name }.to_csv(:row_sep => '')
-      if found_header != expected_header
-        build_warnings(:malformed_header, :schema, 1, nil, found_header, expected_header)
-      end
+      expected_header = @fields.map{ |f| f.name }
 
       if header.to_set != expected_header.to_set
         build_warnings(:malformed_header, :schema, 1, nil, header, expected_header)
       end
-
+      
       return valid?
     end
-
+        
     def validate_row(values, row=nil)
       reset
       if values.length < fields.length
@@ -42,26 +38,26 @@ module Csvlint
           build_warnings(:extra_column, :schema, row, fields.size+i+1)
         end
       end
-
+      
       fields.each_with_index do |field,i|
         value = values[i] || ""
         result = field.validate_column(value, row, i+1)
         @errors += fields[i].errors
-        @warnings += fields[i].warnings
+        @warnings += fields[i].warnings        
       end
-
+            
       return valid?
     end
-
+    
     def Schema.from_json_table(uri, json)
       fields = []
       json["fields"].each do |field_desc|
-        fields << Csvlint::Field.new( field_desc["name"] , field_desc["constraints"],
+        fields << Csvlint::Field.new( field_desc["name"] , field_desc["constraints"], 
           field_desc["title"], field_desc["description"] )
       end if json["fields"]
       return Schema.new( uri , fields, json["title"], json["description"] )
     end
-
+    
     def Schema.load_from_json_table(uri)
       begin
         json = JSON.parse( open(uri).read )
@@ -70,6 +66,6 @@ module Csvlint
         return nil
       end
     end
-
+    
   end
 end

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -136,6 +136,15 @@ describe Csvlint::Schema do
       expect( schema.warnings.first.constraints ).to eql(["minimum"])
 
     end
+    
+    it "should not warn if columns are correct but in different order" do
+      field1 = Csvlint::Field.new("field1")
+      field2 = Csvlint::Field.new("field2")
+      schema = Csvlint::Schema.new("http://example.org", [field1, field2] )
+      
+      expect( schema.validate_header(["field2", "field1"]) ).to eql(true)
+      expect( schema.warnings.size ).to eql(0)
+    end
 
   end
   

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -96,10 +96,10 @@ describe Csvlint::Schema do
       expect( schema.warnings.size ).to eql(1)
       expect( schema.warnings.first.row ).to eql(1)
       expect( schema.warnings.first.type ).to eql(:malformed_header)
-      expect( schema.warnings.first.content ).to eql('wrong,required')
+      expect( schema.warnings.first.content ).to eql(["wrong", "required"])
       expect( schema.warnings.first.column ).to eql(nil)
       expect( schema.warnings.first.category ).to eql(:schema)
-      expect( schema.warnings.first.constraints ).to eql('minimum,required')
+      expect( schema.warnings.first.constraints ).to eql(["minimum","required"])
 
       expect( schema.validate_header(["minimum", "Required"]) ).to eql(true)
       expect( schema.warnings.size ).to eql(1)
@@ -115,10 +115,10 @@ describe Csvlint::Schema do
       expect( schema.warnings.size ).to eql(1)
       expect( schema.warnings.first.row ).to eql(1)
       expect( schema.warnings.first.type ).to eql(:malformed_header)
-      expect( schema.warnings.first.content ).to eql("minimum")
+      expect( schema.warnings.first.content ).to eql(["minimum"])
       expect( schema.warnings.first.column ).to eql(nil)
       expect( schema.warnings.first.category ).to eql(:schema)
-      expect( schema.warnings.first.constraints ).to eql('minimum,required')
+      expect( schema.warnings.first.constraints ).to eql(["minimum","required"])
 
     end
 
@@ -130,10 +130,10 @@ describe Csvlint::Schema do
       expect( schema.warnings.size ).to eql(1)
       expect( schema.warnings.first.row ).to eql(1)
       expect( schema.warnings.first.type ).to eql(:malformed_header)
-      expect( schema.warnings.first.content ).to eql("wrong,required")
+      expect( schema.warnings.first.content ).to eql(["wrong","required"])
       expect( schema.warnings.first.column ).to eql(nil)
       expect( schema.warnings.first.category ).to eql(:schema)
-      expect( schema.warnings.first.constraints ).to eql('minimum')
+      expect( schema.warnings.first.constraints ).to eql(["minimum"])
 
     end
 


### PR DESCRIPTION
This improves upon #127 (as discussed in #126). Mainly:

1. Expected and actual headers are now passed as an array to the warning message, rather than comma separated values
2. A warning is not reported if the headers are correct but in a different order, as [JSON Table Schema](http://dataprotocols.org/json-table-schema/) does not require fields to be in order (correct me if I'm wrong)
