### PR TITLE
Don't pass leading string to parse_line

### DIFF
--- a/lib/csvlint/validate.rb
+++ b/lib/csvlint/validate.rb
@@ -77,7 +77,7 @@ module Csvlint
           validate_metadata
         end
         request.on_body do |chunk|
-          io = StringIO.new(@leading + chunk)
+          io = StringIO.new(chunk)
           io.each_line do |line|
             break if line_limit_reached?
             parse_line(line)


### PR DESCRIPTION
This is a legacy from when `parse_line` was only used within `validate_url`. We now join the leading and the chunk within `parse_line`