### PR TITLE
Further optimisations

### DIFF
--- a/features/csvupload.feature
+++ b/features/csvupload.feature
@@ -17,14 +17,6 @@ Feature: Collect all the tests that should trigger dialect check related errors
     Then there should be 1 info message
     And one of the messages should have the type "nonrfc_line_breaks"
 
-  Scenario: CR line endings in file give an info message of type :nonrfc_line_breaks
-    Given I have a CSV file called "cr-line-endings.csv"
-    And it is stored at the url "http://example.com/example1.csv"
-    And I set header to "true"
-    And I ask if there are info messages
-    Then there should be 1 info message
-    And one of the messages should have the type "nonrfc_line_breaks"
-
   Scenario: CRLF line endings in file produces no info messages of type :nonrfc_line_breaks
     Given I have a CSV file called "crlf-line-endings.csv"
     And it is stored at the url "http://example.com/example1.csv"

--- a/features/validation_info.feature
+++ b/features/validation_info.feature
@@ -8,14 +8,6 @@ Feature: Get validation information messages
     Then there should be 1 info messages
     And one of the messages should have the type "nonrfc_line_breaks"
 
-  Scenario: CR line endings in file give an info message
-    Given I have a CSV file called "cr-line-endings.csv"
-    And it is stored at the url "http://example.com/example1.csv"
-    And I set header to "true"
-    And I ask if there are info messages
-    Then there should be 1 info messages
-    And one of the messages should have the type "nonrfc_line_breaks"
-
   Scenario: CRLF line endings in file produces no info messages
     Given I have a CSV file called "crlf-line-endings.csv"
     And it is stored at the url "http://example.com/example1.csv"

--- a/lib/csvlint/validate.rb
+++ b/lib/csvlint/validate.rb
@@ -274,7 +274,7 @@ module Csvlint
 
     def report_line_breaks(line_no=nil)
       return if @input !~ /[\r|\n]/ # Return straight away if there's no newline character - i.e. we're on the last line
-      line_break = LineCSV.new(@input).row_sep
+      line_break = get_line_break(@input)
       @line_breaks << line_break
       unless line_breaks_reported?
         if line_break != "\r\n"
@@ -559,6 +559,15 @@ module Csvlint
 
     def line_limit_reached?
       @limit_lines.present? && @current_line > @limit_lines
+    end
+
+    def get_line_break(line)
+      eol = line.chars.last(2)
+      if eol.first == "\r"
+        "\r\n"
+      else
+        "\n"
+      end
     end
 
     FORMATS = {

--- a/lib/csvlint/validate.rb
+++ b/lib/csvlint/validate.rb
@@ -399,26 +399,8 @@ module Csvlint
               :numeric
             elsif uri?(col)
               :uri
-            elsif col[FORMATS[:date_db]] && date_format?(Date, col, '%Y-%m-%d')
-              :date_db
-            elsif col[FORMATS[:date_short]] && date_format?(Date, col, '%e %b')
-              :date_short
-            elsif col[FORMATS[:date_rfc822]] && date_format?(Date, col, '%e %b %Y')
-              :date_rfc822
-            elsif col[FORMATS[:date_long]] && date_format?(Date, col, '%B %e, %Y')
-              :date_long
-            elsif col[FORMATS[:dateTime_time]] && date_format?(Time, col, '%H:%M')
-              :dateTime_time
-            elsif col[FORMATS[:dateTime_hms]] && date_format?(Time, col, '%H:%M:%S')
-              :dateTime_hms
-            elsif col[FORMATS[:dateTime_db]] && date_format?(Time, col, '%Y-%m-%d %H:%M:%S')
-              :dateTime_db
-            elsif col[FORMATS[:dateTime_iso8601]] && date_format?(Time, col, '%Y-%m-%dT%H:%M:%SZ')
-              :dateTime_iso8601
-            elsif col[FORMATS[:dateTime_short]] && date_format?(Time, col, '%d %b %H:%M')
-              :dateTime_short
-            elsif col[FORMATS[:dateTime_long]] && date_format?(Time, col, '%B %d, %Y %H:%M')
-              :dateTime_long
+            elsif possible_date?(col)
+              date_formats(col)
             else
               :string
             end
@@ -539,6 +521,36 @@ module Csvlint
       false
     end
 
+    def possible_date?(col)
+      col[POSSIBLE_DATE_REGEXP]
+    end
+
+    def date_formats(col)
+      if col[FORMATS[:date_db]] && date_format?(Date, col, '%Y-%m-%d')
+        :date_db
+      elsif col[FORMATS[:date_short]] && date_format?(Date, col, '%e %b')
+        :date_short
+      elsif col[FORMATS[:date_rfc822]] && date_format?(Date, col, '%e %b %Y')
+        :date_rfc822
+      elsif col[FORMATS[:date_long]] && date_format?(Date, col, '%B %e, %Y')
+        :date_long
+      elsif col[FORMATS[:dateTime_time]] && date_format?(Time, col, '%H:%M')
+        :dateTime_time
+      elsif col[FORMATS[:dateTime_hms]] && date_format?(Time, col, '%H:%M:%S')
+        :dateTime_hms
+      elsif col[FORMATS[:dateTime_db]] && date_format?(Time, col, '%Y-%m-%d %H:%M:%S')
+        :dateTime_db
+      elsif col[FORMATS[:dateTime_iso8601]] && date_format?(Time, col, '%Y-%m-%dT%H:%M:%SZ')
+        :dateTime_iso8601
+      elsif col[FORMATS[:dateTime_short]] && date_format?(Time, col, '%d %b %H:%M')
+        :dateTime_short
+      elsif col[FORMATS[:dateTime_long]] && date_format?(Time, col, '%B %d, %Y %H:%M')
+        :dateTime_long
+      else
+        :string
+      end
+    end
+
     def date_format?(klass, value, format)
       klass.strptime(value, format).strftime(format) == value
     rescue ArgumentError # invalid date
@@ -577,6 +589,7 @@ module Csvlint
     LINK_EXTENSION_REGEXP = Regexp.new("(?<link-extension>(?<param>#{TOKEN_REGEXP})(\\s*=\\s*(?<param-value>#{TOKEN_REGEXP}|#{QUOTED_STRING_REGEXP}))?)")
     LINK_PARAM_REGEXP = Regexp.new("(#{REL_REGEXP}|#{REV_REGEXP}|#{TITLE_REGEXP}|#{ANCHOR_REGEXP}|#{LINK_EXTENSION_REGEXP})")
     LINK_HEADER_REGEXP = Regexp.new("\<#{URI_REGEXP}\>(\\s*;\\s*#{LINK_PARAM_REGEXP})*")
+    POSSIBLE_DATE_REGEXP = Regexp.new("\\A(\\d|\\s\\d#{Date::ABBR_MONTHNAMES.join('|')}#{Date::MONTHNAMES.join('|')})")
 
   end
 end

--- a/lib/csvlint/validate.rb
+++ b/lib/csvlint/validate.rb
@@ -273,7 +273,7 @@ module Csvlint
     end
 
     def report_line_breaks(line_no=nil)
-      return if @input !~ /[\r|\n]/ # Return straight away if there's no newline character - i.e. we're on the last line
+      return unless @input[-1, 1].include?("\n") # Return straight away if there's no newline character - i.e. we're on the last line
       line_break = get_line_break(@input)
       @line_breaks << line_break
       unless line_breaks_reported?

--- a/lib/csvlint/validate.rb
+++ b/lib/csvlint/validate.rb
@@ -21,7 +21,7 @@ module Csvlint
       @dialect = dialect
       @csv_header = true
       @headers = {}
-      @lambda = options[:lambda] || lambda { |a| nil }
+      @lambda = options[:lambda]
       @leading = ""
 
       @limit_lines = options[:limit_lines]
@@ -117,7 +117,7 @@ module Csvlint
       @encoding = input.encoding.to_s
       report_line_breaks(line)
       parse_contents(input, line)
-      @lambda.call(self)
+      @lambda.call(self) unless @lambda.nil?
     rescue ArgumentError => ae
       build_errors(:invalid_encoding, :structure, @current_line, nil, index) unless @reported_invalid_encoding
       @reported_invalid_encoding = true


### PR DESCRIPTION
This does three things:

* Stops calling a lambda if one isn't specified
* Checks to see if a string is a possible date before running all the date regexes in `build_formats ` (if it begins with a number or a month)
* Gets the linebreaks by checking the end of a string, rather than running `CSV.new` again