### PR TITLE
still increment current_line after invalid_encoding error

### DIFF
--- a/lib/csvlint/validate.rb
+++ b/lib/csvlint/validate.rb
@@ -151,6 +151,7 @@ module Csvlint
       end
     rescue ArgumentError => ae
       build_errors(:invalid_encoding, :structure, @current_line, nil, @current_line) unless @reported_invalid_encoding
+      @current_line = @current_line+1
       @reported_invalid_encoding = true
     end
 


### PR DESCRIPTION
This fixes a problem where the line number would not increment after an invalid_encoding error was thrown on a line. All the subsequent errors provided would then show the wrong line number.