### PR TITLE
force UTF-8 if encoding is ASCII-8BIT

### DIFF
--- a/lib/csvlint/validate.rb
+++ b/lib/csvlint/validate.rb
@@ -123,6 +123,7 @@ module Csvlint
         validate_metadata
       end
       request.on_body do |chunk|
+        chunk.force_encoding(Encoding::UTF_8) if chunk.encoding == Encoding::ASCII_8BIT
         io = StringIO.new(chunk)
         io.each_line do |line|
           break if line_limit_reached?


### PR DESCRIPTION
ASCII-8BIT implies that it’s been read from the file system; in that
case, let’s assume UTF-8. I think this should really be picking up the
encoding from the dialect but I’m wary about fiddling around too much
