### PR TITLE
Add row + col to foreign key & duplicate key errors

### DIFF
--- a/lib/csvlint/csvw/table.rb
+++ b/lib/csvlint/csvw/table.rb
@@ -62,7 +62,8 @@ module Csvlint
         if validate
           unless @primary_key.nil?
             key = @primary_key.map { |column| column.validate(values[column.number - 1], row) }
-            build_errors(:duplicate_key, :schema, row, column.number, key.join(","), @primary_key_values[key]) if @primary_key_values.include?(key)
+            colnum = if primary_key.length == 1 then primary_key[0].number else nil end
+            build_errors(:duplicate_key, :schema, row, colnum, key.join(","), @primary_key_values[key]) if @primary_key_values.include?(key)
             @primary_key_values[key] = row
           end
           # build a record of the unique values that are referenced by foreign keys from other tables

--- a/lib/csvlint/csvw/table.rb
+++ b/lib/csvlint/csvw/table.rb
@@ -62,7 +62,7 @@ module Csvlint
         if validate
           unless @primary_key.nil?
             key = @primary_key.map { |column| column.validate(values[column.number - 1], row) }
-            build_errors(:duplicate_key, :schema, row, nil, key.join(","), @primary_key_values[key]) if @primary_key_values.include?(key)
+            build_errors(:duplicate_key, :schema, row, column.number, key.join(","), @primary_key_values[key]) if @primary_key_values.include?(key)
             @primary_key_values[key] = row
           end
           # build a record of the unique values that are referenced by foreign keys from other tables
@@ -103,11 +103,12 @@ module Csvlint
         reset
         local = @foreign_key_reference_values[foreign_key]
         context = { "from" => { "url" => remote_url.to_s.split("/")[-1], "columns" => foreign_key["columnReference"] }, "to" => { "url" => @url.to_s.split("/")[-1], "columns" => foreign_key["reference"]["columnReference"] }}
-        remote.each do |r|
+        colnum = if foreign_key["referencing_columns"].length == 1 then foreign_key["referencing_columns"][0].number else nil end
+        remote.each_with_index do |r,i|
           if local[r]
-            build_errors(:multiple_matched_rows, :schema, nil, nil, r, context) if local[r].length > 1
+            build_errors(:multiple_matched_rows, :schema, i+1, colnum, r, context) if local[r].length > 1
           else
-            build_errors(:unmatched_foreign_key_reference, :schema, nil, nil, r, context)
+            build_errors(:unmatched_foreign_key_reference, :schema, i+1, colnum, r, context)
           end
         end
         return valid?


### PR DESCRIPTION
Improvements to output on foreign key error and duplicate key error:

* Sets "row" on foreign key error (it used to always be nil)

* Sets "col" on foreign key error and on duplicate key error, where the key has exactly one column.  Otherwise "col" remains nil.