### PR TITLE
Perform foreign key checks even if empty tables exist ...

### DIFF
--- a/lib/csvlint/csvw/table.rb
+++ b/lib/csvlint/csvw/table.rb
@@ -92,6 +92,7 @@ module Csvlint
         reset
         @foreign_keys.each do |foreign_key|
           local = @foreign_key_values[foreign_key]
+          next if local.nil?
           remote_table = foreign_key["referenced_table"]
           remote_table.validate_foreign_key_references(foreign_key, @url, local)
           @errors += remote_table.errors unless remote_table == self

--- a/lib/csvlint/csvw/table_group.rb
+++ b/lib/csvlint/csvw/table_group.rb
@@ -23,6 +23,7 @@ module Csvlint
       def validate_header(header, table_url, strict)
         reset
         table_url = "file:#{File.absolute_path(table_url)}" if table_url.instance_of? File
+        @validated_tables[table_url] = true
         table = tables[table_url]
         table.validate_header(header, strict)
         @errors += table.errors


### PR DESCRIPTION
* Tables with 0 rows are still valid tables ... mark table valid on seeing header *or* data row.

* This was preventing foreign key checks from running if *any* table was empty because of the
    `unless @validated_tables.has_value?(false)` in `TableGroup.validate_foreign_keys`