### PR TITLE
Fix foreign key checks & reporting

### DIFF
--- a/lib/csvlint/csvw/table.rb
+++ b/lib/csvlint/csvw/table.rb
@@ -107,9 +107,9 @@ module Csvlint
         colnum = if foreign_key["referencing_columns"].length == 1 then foreign_key["referencing_columns"][0].number else nil end
         remote.each_with_index do |r,i|
           if local[r]
-            build_errors(:multiple_matched_rows, :schema, i+1, colnum, r, context) if local[r].length > 1
+            build_errors(:multiple_matched_rows, :schema, nil, colnum, r, context) if local[r].length > 1
           else
-            build_errors(:unmatched_foreign_key_reference, :schema, i+1, colnum, r, context)
+            build_errors(:unmatched_foreign_key_reference, :schema, nil, colnum, r, context)
           end
         end
         return valid?

--- a/lib/csvlint/version.rb
+++ b/lib/csvlint/version.rb
@@ -1,3 +1,3 @@
 module Csvlint
-  VERSION = "0.3.3"
+  VERSION = "0.3.3.nick2"
 end

--- a/lib/csvlint/version.rb
+++ b/lib/csvlint/version.rb
@@ -1,3 +1,3 @@
 module Csvlint
-  VERSION = "0.3.3.nick2"
+  VERSION = "0.3.3"
 end


### PR DESCRIPTION
**Fix foreign key row reporting**

My previous PR added a 'row' to the FK error, but it turned out to be wrong in many cases as it was actually a count of how many unique FK refs there were: this version generates a separate error record per FK violation and thus gives better feedback.

**Run FK checks even if a table is empty**

Previously, if any tables were empty (eg: a header but 0 rows) they wouldn't be marked as "valid" internally, so FK checks would not run.  This PR fixes that by marking an empty table with a valid header as valid.


