### PR TITLE
Fix foreign key row reporting and empty table checks

### DIFF
--- a/lib/csvlint/csvw/table.rb
+++ b/lib/csvlint/csvw/table.rb
@@ -71,9 +71,8 @@ module Csvlint
           @foreign_key_references.each do |foreign_key|
             referenced_columns = foreign_key["referenced_columns"]
             key = referenced_columns.map{ |column| column.validate(values[column.number - 1], row) }
-            known_values = @foreign_key_reference_values[foreign_key] = @foreign_key_reference_values[foreign_key] || {}
-            known_values[key] = known_values[key] || []
-            known_values[key] << row
+            known_values = @foreign_key_reference_values[foreign_key] ||= {}
+            (known_values[key] ||= []) << row
           end
           # build a record of the references from this row to other tables
           # we can't check yet whether these exist in the other tables because
@@ -81,8 +80,8 @@ module Csvlint
           @foreign_keys.each do |foreign_key|
             referencing_columns = foreign_key["referencing_columns"]
             key = referencing_columns.map{ |column| column.validate(values[column.number - 1], row) }
-            known_values = @foreign_key_values[foreign_key] = @foreign_key_values[foreign_key] || []
-            known_values << key unless known_values.include?(key)
+            known_values = @foreign_key_values[foreign_key] ||= {}
+            (known_values[key] ||= []) << row
           end
         end
         return valid?
@@ -92,6 +91,7 @@ module Csvlint
         reset
         @foreign_keys.each do |foreign_key|
           local = @foreign_key_values[foreign_key]
+          next if local.nil?
           remote_table = foreign_key["referenced_table"]
           remote_table.validate_foreign_key_references(foreign_key, @url, local)
           @errors += remote_table.errors unless remote_table == self
@@ -103,13 +103,22 @@ module Csvlint
       def validate_foreign_key_references(foreign_key, remote_url, remote)
         reset
         local = @foreign_key_reference_values[foreign_key]
-        context = { "from" => { "url" => remote_url.to_s.split("/")[-1], "columns" => foreign_key["columnReference"] }, "to" => { "url" => @url.to_s.split("/")[-1], "columns" => foreign_key["reference"]["columnReference"] }}
+        context = {
+          "from" => { "url" => remote_url.to_s.split("/")[-1], "columns" => foreign_key["columnReference"] },
+          "to" => { "url" => @url.to_s.split("/")[-1], "columns" => foreign_key["reference"]["columnReference"] }
+        }
+
+
         colnum = if foreign_key["referencing_columns"].length == 1 then foreign_key["referencing_columns"][0].number else nil end
-        remote.each_with_index do |r,i|
-          if local[r]
-            build_errors(:multiple_matched_rows, :schema, i+1, colnum, r, context) if local[r].length > 1
-          else
-            build_errors(:unmatched_foreign_key_reference, :schema, i+1, colnum, r, context)
+        remote.each do |key,rows|
+          if not local[key]
+            rows.each do |row|
+              build_errors(:unmatched_foreign_key_reference, :schema, row, colnum, key, context)
+            end
+          elsif local[key].length > 1
+            rows.each do |row|
+              build_errors(:multiple_matched_rows, :schema, row, colnum, key, context)
+            end
           end
         end
         return valid?

--- a/lib/csvlint/csvw/table_group.rb
+++ b/lib/csvlint/csvw/table_group.rb
@@ -23,6 +23,7 @@ module Csvlint
       def validate_header(header, table_url, strict)
         reset
         table_url = "file:#{File.absolute_path(table_url)}" if table_url.instance_of? File
+        @validated_tables[table_url] = true
         table = tables[table_url]
         table.validate_header(header, strict)
         @errors += table.errors


### PR DESCRIPTION
### Fix foreign key row reporting

My previous PR added a 'row' to the FK error, but it turned out to be wrong in many cases as it was actually a count of how many unique FK refs there were: this version generates a separate error record per FK violation and thus gives better feedback.  To do this is keeps a list of all rows which use a foreign key, which will use slightly more memory than before, but it also uses a hash to store the known values which should be somewhat quicker.

### Run FK checks even if a table is empty

Previously, if any tables were empty (eg: a header but 0 rows) they wouldn't be marked as "valid" internally, so FK checks would not run. This PR fixes that by marking an empty table with a valid header as valid.  This was originally PR #190 but these issues are entangled so I'm closing that one and submitting this merged PR.